### PR TITLE
Fixed several bugs in the latest release

### DIFF
--- a/drivers/home/device.ts
+++ b/drivers/home/device.ts
@@ -273,7 +273,7 @@ class HomeDevice extends Device {
       this.log(`Begin update`);
 
       const priceInfoNextHours = await this.#tibber.getPriceInfoCached(
-        this.homey.setTimeout,
+          (callback, ms, args) => this.homey.setTimeout(callback, ms, args),
       );
       this.onPriceData(priceInfoNextHours).catch(() => {});
 

--- a/drivers/home/device.ts
+++ b/drivers/home/device.ts
@@ -14,7 +14,7 @@ import {
 const priceLevelMap = {
   LOW: 'CHEAP',
   NORMAL: 'NORMAL',
-  HIGH: 'HIGH',
+  HIGH: 'EXPENSIVE',
 };
 
 class HomeDevice extends Device {

--- a/drivers/home/device.ts
+++ b/drivers/home/device.ts
@@ -56,7 +56,7 @@ class HomeDevice extends Device {
     // and `price_level` was deprecated in favor of `measure_price_level` (because it went from 5 enum values to 3)
     // we don't want to remove them completely and break users' flow cards using them
     this.#hasDeprecatedTotalPriceCapability = this.hasCapability('price_total');
-    this.#hasDeprecatedTotalPriceCapability = this.hasCapability('price_level');
+    this.#hasDeprecatedPriceLevelCapability = this.hasCapability('price_level');
 
     const data = this.getData();
     const { id: homeId, t: token } = data;


### PR DESCRIPTION
**Background:**
Tibber released version 1.5.5 of the Homey App three days ago. It was quickly evident for users that there were some bugs that basically stopped users using the app as they normally would. Users posted and are still posting non-working app issues to the "Athom Homey Norge" group:
https://www.facebook.com/groups/1749985315078059?sorting_setting=CHRONOLOGICAL

**Bug fixes**
- Two bugs relevant to the mapping to the old level values causing the old level value in effect to not work at all
- One bug that made no trigger work after 13:00. This was caused by an exception in the call to "homeySetTimeout" in getPriceInfoCached

